### PR TITLE
More idiomatic ways of handling nil

### DIFF
--- a/containers/deque.cr
+++ b/containers/deque.cr
@@ -40,17 +40,17 @@ class Deque(T)
   end
 
   def front
-    @front.nil? ? nil : @front.not_nil!.data
+    @front.try &.data
   end
 
   def back
-    @back.nil? ? nil : @back.not_nil!.data
+    @back.try &.data
   end
 
   def push_front(obj)
     node = Node.new(obj, nil, nil)
-    unless @front.nil?
-      @front.not_nil!.next = node
+    if front = @front
+      front.next = node
       node.prev = @front
       @front = node
     else
@@ -62,8 +62,8 @@ class Deque(T)
 
   def push_back(obj)
     node = Node.new(obj, nil, nil)
-    unless @back.nil?
-      @back.not_nil!.next = node
+    if back = @back
+      back.next = node
       node.prev = @back
       @back = node
     else
@@ -74,8 +74,9 @@ class Deque(T)
   end
 
   def pop_front
-    return nil if @front.nil?
-    front = @front.not_nil!
+    front = @front
+    return unless front
+
     if @size == 1
       data = front.data
       clear
@@ -90,8 +91,9 @@ class Deque(T)
   end
 
   def pop_back
-    return nil if @back.nil?
-    back = @back.not_nil!
+    back = @back
+    return unless back
+
     if @size == 1
       data = back.data
       clear
@@ -107,8 +109,7 @@ class Deque(T)
 
   def each
     node = @front
-    until node.nil?
-      node = node.not_nil!
+    while node
       yield node.data as T
       node = node.next
     end
@@ -116,8 +117,7 @@ class Deque(T)
 
   def reverse_each
     node = @back
-    until node.nil?
-      node = node.not_nil!
+    while node
       yield node.data as T
       node = node.prev
     end

--- a/containers/trie.cr
+++ b/containers/trie.cr
@@ -23,8 +23,7 @@ class Trie
   end
 
   def get(key : String)
-    node = get_recursive(@root, key, 0)
-    node.nil? ? nil : node.not_nil!.value
+    get_recursive(@root, key, 0).try &.value
   end
   alias_method "[]", "get"
 
@@ -61,7 +60,7 @@ class Trie
     node = node.not_nil!
     arr = [] of String
     char = string[index]
-    node_char = node.char.not_nil!
+    node_char = node.char
 
     if (char == '*' || char == '.' || char < node_char)
       arr.concat wildcard_recursive(node.left, string, index, prefix)
@@ -79,12 +78,12 @@ class Trie
 
   private def prefix_recursive(node : Node | Nil, string, index)
     return 0 if node.nil? || index == string.length
-    
+
     node = node.not_nil!
     len = 0
     rec_len = 0
     char = string[index]
-    node_char = node.char.not_nil!
+    node_char = node.char
 
     if (char < node_char)
       rec_len = prefix_recursive(node.left, string, index)
@@ -99,9 +98,8 @@ class Trie
 
   private def push_recursive(node : Node | Nil, string, index, value)
     char = string[index]
-    node = Node.new(char, value) if node.nil?
-    node = node.not_nil!
-    node_char = node.char.not_nil!
+    node ||= Node.new(char, value)
+    node_char = node.char
 
     if (char < node_char)
       node.left = push_recursive(node.left, string, index, value)
@@ -117,11 +115,10 @@ class Trie
   end
 
   private def get_recursive(node : Node | Nil, string, index)
-    return nil if node.nil?
-    
+    return unless node
+
     char = string[index]
-    node = node.not_nil!
-    node_char = node.char.not_nil!
+    node_char = node.char
 
     if (char < node_char)
       return get_recursive(node.left, string, index)


### PR DESCRIPTION
Hi!

I saw lots of `nil?` and `not_nil!` in your code and I thought I'd send you this pull request with more idiomatic ways of handling nil.

Instead of:

``` ruby
unless some_value.nil?
  some_value.not_nil!.some_method
end
```

You can do:

``` ruby
if some_value
  some_value.some_method
end
```

More about this [here](http://crystal-lang.org/docs/syntax_and_semantics/if_var.html). As it says there, that doesn't work for instance variables so you have to assign them to a temporary variable (by now we are doing that all over the place: it's idiomatic and also efficient, as the nil check is done only once).

You can also use `try` if it's just a one liner:

``` ruby
some_value.try &.some_method
```

The above is the same as:

``` ruby
some_value.try { |v| v.some_method }
```

(so you can actually use `try` for more than one line, but I think using a `if` is clearer in those cases)

Don't be afraid of using blocks because of possible performance issues. I don't know about Ruby, but in Crystal, if a method doesn't captures a block (accesses it via it's name), then a closure is never generated and the call is always inlined. So this:

``` ruby
10.times { puts 1 }
```

Is exactly the same as writing this:

``` ruby
i = 0
while i < 10
  puts 1
  i += 1
end
```

When I say "exactly the same" I mean it: the compiler generates the same code in both cases (even when you compile without the `--release` flag).

Also, this:

``` ruby
def foo(x)
  return unless x

  x.some_method
end
```

The compiler knows that if there's no `x` (`x` is _falsey_) then the method will return, so afterwards it knows that `x` can't be `nil`.

In general we try to avoid `not_nil!` unless there's no way the compiler can know we know a value is not nil (but we may be wrong ;)).
