### PR TITLE
Removed 'require "./deque"' everywhere

### DIFF
--- a/containers/queue.cr
+++ b/containers/queue.cr
@@ -1,4 +1,3 @@
-require "./deque"
 require "./common"
 
 class Queue(T)

--- a/containers/stack.cr
+++ b/containers/stack.cr
@@ -1,4 +1,3 @@
-require "./deque"
 require "./common"
 
 class Stack(T)


### PR DESCRIPTION
Unneeded anyway, fixes compile failure on crystal 0.24